### PR TITLE
various fixes for OSX build

### DIFF
--- a/AlembicImporter/Assets/AlembicImporter/Scripts/AlembicImporter.cs
+++ b/AlembicImporter/Assets/AlembicImporter/Scripts/AlembicImporter.cs
@@ -52,8 +52,9 @@ public class AlembicImporter
         public System.IntPtr ptr;
     }
 
-
+#if UNITY_STANDALONE_WIN
     [DllImport ("AddLibraryPath")] public static extern void        AddLibraryPath();
+#endif
 
     [DllImport ("AlembicImporter")] public static extern aiContext  aiCreateContext();
     [DllImport ("AlembicImporter")] public static extern void       aiDestroyContext(aiContext ctx);
@@ -136,7 +137,9 @@ public class AlembicImporter
     {
         if (path=="") return;
 
+#if UNITY_STANDALONE_WIN
         AlembicImporter.AddLibraryPath();
+#endif
         aiContext ctx = aiCreateContext();
         if (!aiLoad(ctx, Application.streamingAssetsPath + "/" + path))
         {

--- a/AlembicImporter/Assets/AlembicImporter/Scripts/AlembicStream.cs
+++ b/AlembicImporter/Assets/AlembicImporter/Scripts/AlembicStream.cs
@@ -23,7 +23,9 @@ public class AlembicStream : MonoBehaviour
 
     void OnEnable()
     {
+#if UNITY_STANDALONE_WIN
         AlembicImporter.AddLibraryPath();
+#endif
         m_abc = AlembicImporter.aiCreateContext();
         m_loaded = AlembicImporter.aiLoad(m_abc, m_path_to_abc);
     }

--- a/AlembicImporterPlugin/AlembicImporter.cpp
+++ b/AlembicImporterPlugin/AlembicImporter.cpp
@@ -24,7 +24,7 @@ void aiDebugLogImpl(const char* fmt, ...)
     vsprintf(buf, fmt, vl);
     ::OutputDebugStringA(buf);
 #else // aiWindows
-    vprintf(vl);
+    vprintf(fmt, vl);
 #endif // aiWindows
 
     va_end(vl);
@@ -152,13 +152,17 @@ aiCLinkage aiExport bool aiXFormGetInherits(aiObject* obj)
 aiCLinkage aiExport aiV3 aiXFormGetPosition(aiObject* obj)
 {
     aiCheckObject(obj);
-    return (aiV3&)obj->getXForm().getPosition();
+    abcV3 p = obj->getXForm().getPosition();
+    aiV3 rv = {p.x, p.y, p.z};
+    return rv;
 }
 
 aiCLinkage aiExport aiV3 aiXFormGetAxis(aiObject* obj)
 {
     aiCheckObject(obj);
-    return (aiV3&)obj->getXForm().getAxis();
+    abcV3 a = obj->getXForm().getAxis();
+    aiV3 rv = {a.x, a.y, a.z};
+    return rv;
 }
 
 aiCLinkage aiExport float aiXFormGetAngle(aiObject* obj)
@@ -170,13 +174,20 @@ aiCLinkage aiExport float aiXFormGetAngle(aiObject* obj)
 aiCLinkage aiExport aiV3 aiXFormGetScale(aiObject* obj)
 {
     aiCheckObject(obj);
-    return (aiV3&)obj->getXForm().getScale();
+    abcV3 s = obj->getXForm().getScale();
+    aiV3 rv = {s.x, s.y, s.z};
+    return rv;
 }
 
 aiCLinkage aiExport aiM44 aiXFormGetMatrix(aiObject* obj)
 {
     aiCheckObject(obj);
-    return (aiM44&)obj->getXForm().getMatrix();
+    abcM44 m = obj->getXForm().getMatrix();
+    aiM44 rv;
+    for (int i=0; i<4; ++i)
+        for (int j=0; j<4; ++j)
+            rv.v[i][j] = m.x[i][j];
+    return rv;
 }
 
 

--- a/AlembicImporterPlugin/AlembicImporter.h
+++ b/AlembicImporterPlugin/AlembicImporter.h
@@ -8,7 +8,12 @@
 
 
 
-typedef void(__stdcall *aiNodeEnumerator)(aiObject *node, void *userdata);
+#ifdef _WIN32
+typedef void (__stdcall *aiNodeEnumerator)(aiObject *node, void *userdata);
+#else
+typedef void (*aiNodeEnumerator)(aiObject *node, void *userdata);
+#endif
+
 struct aiV2 { float v[2]; };
 struct aiV3 { float v[3]; };
 struct aiM44 { float v[4][4]; };

--- a/AlembicImporterPlugin/aiContext.cpp
+++ b/AlembicImporterPlugin/aiContext.cpp
@@ -36,7 +36,8 @@ void aiContext::gatherNodesRecursive(aiObject *n)
     abcObject &abc = n->getAbcObject();
     int num_children = abc.getNumChildren();
     for (int i = 0; i < num_children; ++i) {
-        aiObject *child = new aiObject(this, abc.getChild(i));
+        abcObject abcChild = abc.getChild(i);
+        aiObject *child = new aiObject(this, abcChild);
         n->addChild(child);
         gatherNodesRecursive(child);
     }
@@ -65,7 +66,8 @@ bool aiContext::load(const char *path)
     }
 
     if (m_archive && m_archive->valid()) {
-        aiObject *top = new aiObject(this, m_archive->getTop());
+        abcObject abcTop = m_archive->getTop();
+        aiObject *top = new aiObject(this, abcTop);
         gatherNodesRecursive(top);
 
         aiDebugLog("succeeded\n");

--- a/AlembicImporterPlugin/aiGeometry.cpp
+++ b/AlembicImporterPlugin/aiGeometry.cpp
@@ -223,7 +223,7 @@ bool aiPolyMesh::getSplitedMeshInfo(aiSplitedMeshInfo &o_smi, const aiSplitedMes
     smi.begin_index = prev.begin_index + prev.num_indices;
 
     bool is_end = true;
-    uint32_t a = 0;
+    int a = 0;
     for (size_t i = smi.begin_face; i < nc; ++i) {
         int ngon = counts[i];
         if (a + ngon >= max_vertices) {
@@ -252,7 +252,7 @@ void aiPolyMesh::copySplitedIndices(int *dst, const aiSplitedMeshInfo &smi) cons
     uint32_t b = 0;
     uint32_t i1 = reverse_index ? 2 : 1;
     uint32_t i2 = reverse_index ? 1 : 2;
-    for (size_t fi = 0; fi < smi.num_faces; ++fi) {
+    for (int fi = 0; fi < smi.num_faces; ++fi) {
         int ngon = counts[smi.begin_face + fi];
         for (int ni = 0; ni < (ngon - 2); ++ni) {
             dst[b + 0] = a;
@@ -271,7 +271,7 @@ void aiPolyMesh::copySplitedVertices(abcV3 *dst, const aiSplitedMeshInfo &smi) c
     const auto &positions = *m_positions;
 
     uint32_t a = 0;
-    for (size_t fi = 0; fi < smi.num_faces; ++fi) {
+    for (int fi = 0; fi < smi.num_faces; ++fi) {
         int ngon = counts[smi.begin_face + fi];
         for (int ni = 0; ni < ngon; ++ni) {
             dst[a + ni] = positions[indices[a + ni + smi.begin_index]];
@@ -294,7 +294,7 @@ void aiPolyMesh::copySplitedNormals(abcV3 *dst, const aiSplitedMeshInfo &smi) co
     if (m_normals.isIndexed())
     {
         uint32_t a = 0;
-        for (size_t fi = 0; fi < smi.num_faces; ++fi) {
+        for (int fi = 0; fi < smi.num_faces; ++fi) {
             int ngon = counts[smi.begin_face + fi];
             for (int ni = 0; ni < ngon; ++ni) {
                 dst[a + ni] = normals[indices[a + ni + smi.begin_index]];
@@ -305,7 +305,7 @@ void aiPolyMesh::copySplitedNormals(abcV3 *dst, const aiSplitedMeshInfo &smi) co
     else
     {
         uint32_t a = 0;
-        for (size_t fi = 0; fi < smi.num_faces; ++fi) {
+        for (int fi = 0; fi < smi.num_faces; ++fi) {
             int ngon = counts[smi.begin_face + fi];
             for (int ni = 0; ni < ngon; ++ni) {
                 dst[a + ni] = normals[a + ni];
@@ -329,7 +329,7 @@ void aiPolyMesh::copySplitedUVs(abcV2 *dst, const aiSplitedMeshInfo &smi) const
     if (m_uvs.isIndexed())
     {
         uint32_t a = 0;
-        for (size_t fi = 0; fi < smi.num_faces; ++fi) {
+        for (int fi = 0; fi < smi.num_faces; ++fi) {
             int ngon = counts[smi.begin_face + fi];
             for (int ni = 0; ni < ngon; ++ni) {
                 dst[a + ni] = uvs[indices[a + ni + smi.begin_index]];
@@ -340,7 +340,7 @@ void aiPolyMesh::copySplitedUVs(abcV2 *dst, const aiSplitedMeshInfo &smi) const
     else
     {
         uint32_t a = 0;
-        for (size_t fi = 0; fi < smi.num_faces; ++fi) {
+        for (int fi = 0; fi < smi.num_faces; ++fi) {
             int ngon = counts[smi.begin_face + fi];
             for (int ni = 0; ni < ngon; ++ni) {
                 dst[a + ni] = uvs[a + ni];

--- a/AlembicImporterPlugin/aiObject.cpp
+++ b/AlembicImporterPlugin/aiObject.cpp
@@ -19,37 +19,51 @@ aiObject::aiObject(aiContext *ctx, abcObject &abc)
     if (m_abc.valid())
     {
         const auto& metadata = m_abc.getMetaData();
-        if (m_has_xform = AbcGeom::IXformSchema::matches(metadata))
+        
+        m_has_xform = AbcGeom::IXformSchema::matches(metadata);
+        if (m_has_xform)
         {
             m_xform = aiXForm(this);
             m_schemas.push_back(&m_xform);
         }
-        if (m_has_polymesh = AbcGeom::IPolyMeshSchema::matches(metadata))
+        
+        m_has_polymesh = AbcGeom::IPolyMeshSchema::matches(metadata);
+        if (m_has_polymesh)
         {
             m_polymesh = aiPolyMesh(this);
             m_schemas.push_back(&m_polymesh);
         }
-        if (m_has_curves = AbcGeom::ICurvesSchema::matches(metadata))
+        
+        m_has_curves = AbcGeom::ICurvesSchema::matches(metadata);
+        if (m_has_curves)
         {
             m_curves = aiCurves(this);
             m_schemas.push_back(&m_curves);
         }
-        if (m_has_points = AbcGeom::IPointsSchema::matches(metadata))
+        
+        m_has_points = AbcGeom::IPointsSchema::matches(metadata);
+        if (m_has_points)
         {
             m_points = aiPoints(this);
             m_schemas.push_back(&m_points);
         }
-        if (m_has_camera = AbcGeom::ICameraSchema::matches(metadata))
+        
+        m_has_camera = AbcGeom::ICameraSchema::matches(metadata);
+        if (m_has_camera)
         {
             m_camera = aiCamera(this);
             m_schemas.push_back(&m_camera);
         }
-        if (m_has_light = AbcGeom::ILight::matches(metadata))
+        
+        m_has_light = AbcGeom::ILight::matches(metadata);
+        if (m_has_light)
         {
             m_light = aiLight(this);
             m_schemas.push_back(&m_light);
         }
-        if (m_has_material = AbcMaterial::IMaterial::matches(metadata))
+        
+        m_has_material = AbcMaterial::IMaterial::matches(metadata);
+        if (m_has_material)
         {
             m_material = aiMaterial(this);
             m_schemas.push_back(&m_material);

--- a/AlembicImporterPlugin/pch.h
+++ b/AlembicImporterPlugin/pch.h
@@ -11,23 +11,6 @@
 #include <Alembic/AbcGeom/All.h>
 #include <Alembic/AbcMaterial/All.h>
 
-#pragma comment(lib, "AlembicAbc.lib")
-#pragma comment(lib, "AlembicAbcCollection.lib")
-#pragma comment(lib, "AlembicAbcCoreAbstract.lib")
-#pragma comment(lib, "AlembicAbcCoreFactory.lib")
-#pragma comment(lib, "AlembicAbcCoreHDF5.lib")
-#pragma comment(lib, "AlembicAbcCoreOgawa.lib")
-#pragma comment(lib, "AlembicAbcGeom.lib")
-#pragma comment(lib, "AlembicAbcMaterial.lib")
-#pragma comment(lib, "AlembicOgawa.lib")
-#pragma comment(lib, "AlembicUtil.lib")
-#pragma comment(lib, "libhdf5.lib")
-#pragma comment(lib, "libhdf5_hl.lib")
-#pragma comment(lib, "Half.lib")
-#pragma comment(lib, "Iex-2_2.lib")
-#pragma comment(lib, "IexMath-2_2.lib")
-
-
 #ifdef _WIN32
 #define aiWindows
 #endif // _WIN32
@@ -36,7 +19,7 @@
 #ifdef _MSC_VER
 #define aiExport __declspec(dllexport)
 #else
-#define aiExport
+#define aiExport __attribute__((visibility("default")))
 #endif
 
 #ifdef aiDebug
@@ -55,9 +38,29 @@ void aiDebugLogImpl(const char* fmt, ...);
 
 #ifdef aiWindows
 #include <windows.h>
-#include <d3d11.h>
 
-#define aiSupportD3D11
+#ifndef aiNoAutoLink
+#pragma comment(lib, "AlembicAbc.lib")
+#pragma comment(lib, "AlembicAbcCollection.lib")
+#pragma comment(lib, "AlembicAbcCoreAbstract.lib")
+#pragma comment(lib, "AlembicAbcCoreFactory.lib")
+#pragma comment(lib, "AlembicAbcCoreHDF5.lib")
+#pragma comment(lib, "AlembicAbcCoreOgawa.lib")
+#pragma comment(lib, "AlembicAbcGeom.lib")
+#pragma comment(lib, "AlembicAbcMaterial.lib")
+#pragma comment(lib, "AlembicOgawa.lib")
+#pragma comment(lib, "AlembicUtil.lib")
+#pragma comment(lib, "libhdf5.lib")
+#pragma comment(lib, "libhdf5_hl.lib")
+#pragma comment(lib, "Half.lib")
+#pragma comment(lib, "Iex-2_2.lib")
+#pragma comment(lib, "IexMath-2_2.lib")
+#endif // aiNoAutoLink
+
+#ifdef aiSupportD3D11
+#include <d3d11.h>
+#endif // aiSupportD3D11
+
 #endif // aiWindows
 
 using namespace Alembic;


### PR DESCRIPTION
move location of auto link pragmas to windows specific section
add aiNoAutoLink define to disable library auto linking using pragmas
do not use AddLibraryPath plugin on other platform than windows, rely on rpath instead
do not force define aiSupportD3D11 on windows