### PR TITLE
Fix for Stream player properties failing to be updated

### DIFF
--- a/AlembicImporter/Assets/UTJ/AlembicImporter/Editor/AlembicStreamPlayerEditor.cs
+++ b/AlembicImporter/Assets/UTJ/AlembicImporter/Editor/AlembicStreamPlayerEditor.cs
@@ -14,13 +14,10 @@ namespace UTJ.Alembic
 			SerializedProperty iterator = this.serializedObject.GetIterator();
 			for (bool enterChildren = true; iterator.NextVisible(enterChildren); enterChildren = false)
 			{
-                using (new EditorGUI.DisabledScope(false))
-                {
-                    EditorGUILayout.PropertyField(iterator, true, new GUILayoutOption[0]);                    
-                }
+				using (new EditorGUI.DisabledScope(false))
+					EditorGUILayout.PropertyField(iterator, true, new GUILayoutOption[0]);                    
 			}
-            this.serializedObject.ApplyModifiedProperties();
-        }
-
-    }
+			this.serializedObject.ApplyModifiedProperties();
+		}
+	}
 }

--- a/AlembicImporter/Assets/UTJ/AlembicImporter/Editor/AlembicStreamPlayerEditor.cs
+++ b/AlembicImporter/Assets/UTJ/AlembicImporter/Editor/AlembicStreamPlayerEditor.cs
@@ -14,10 +14,13 @@ namespace UTJ.Alembic
 			SerializedProperty iterator = this.serializedObject.GetIterator();
 			for (bool enterChildren = true; iterator.NextVisible(enterChildren); enterChildren = false)
 			{
-				using (new EditorGUI.DisabledScope(false))
-					EditorGUILayout.PropertyField(iterator, true, new GUILayoutOption[0]);
+                using (new EditorGUI.DisabledScope(false))
+                {
+                    EditorGUILayout.PropertyField(iterator, true, new GUILayoutOption[0]);                    
+                }
 			}
-		}
+            this.serializedObject.ApplyModifiedProperties();
+        }
 
-	}
+    }
 }


### PR DESCRIPTION
The edits weren't being applied to the SerializedPropety.