### PR TITLE
Store relative paths in Stream Descriptors, to avoid loading errors in builds

### DIFF
--- a/AlembicImporter/Assets/UTJ/Alembic/Editor/Importer/AlembicImporter.cs
+++ b/AlembicImporter/Assets/UTJ/Alembic/Editor/Importer/AlembicImporter.cs
@@ -100,7 +100,7 @@ namespace UTJ.Alembic
             
             AlembicStreamDescriptor streamDescriptor = ScriptableObject.CreateInstance<AlembicStreamDescriptor>();
             streamDescriptor.name = go.name + "_ABCDesc";
-            streamDescriptor.pathToAbc = destPath;
+            streamDescriptor.pathToAbc = shortAssetPath;
             streamDescriptor.settings = streamSettings;
 
             using (var abcStream = new AlembicStream(go, streamDescriptor))

--- a/AlembicImporter/Assets/UTJ/Alembic/Scripts/Importer/AlembicStream.cs
+++ b/AlembicImporter/Assets/UTJ/Alembic/Scripts/Importer/AlembicStream.cs
@@ -13,7 +13,7 @@ namespace UTJ.Alembic
             var fullPath = Application.streamingAssetsPath + path;
             AbcAPI.clearContextsWithPath(fullPath);
             s_Streams.ForEach(s => {
-                if (s.m_StreamDesc.pathToAbc == fullPath)
+                if (s.m_StreamDesc.pathToAbc == path)
                 {
                     s.m_StreamInterupted = true;
                     s.m_Context = default(AbcAPI.aiContext);
@@ -28,10 +28,10 @@ namespace UTJ.Alembic
             var fullNewPath = Application.streamingAssetsPath + newPath;
             s_Streams.ForEach(s =>
             {
-                if (s.m_StreamDesc.pathToAbc == fullOldPath)
+                if (s.m_StreamDesc.pathToAbc == oldPath)
                 {
                     s.m_StreamInterupted = true;
-                    s.m_StreamDesc.pathToAbc = fullNewPath;
+                    s.m_StreamDesc.pathToAbc = newPath;
                 }
             } );
         } 
@@ -41,7 +41,7 @@ namespace UTJ.Alembic
             var fullPath = Application.streamingAssetsPath + path;
             s_Streams.ForEach(s =>
             {
-                if (s.m_StreamDesc.pathToAbc == fullPath)
+                if (s.m_StreamDesc.pathToAbc == path)
                 {
                     s.m_StreamInterupted = false;
                 }
@@ -173,7 +173,7 @@ namespace UTJ.Alembic
 #endif
                 AbcAPI.aiSetConfig(m_Context, ref m_Config);
 
-            m_Loaded = AbcAPI.aiLoad(m_Context,m_StreamDesc.pathToAbc);
+            m_Loaded = AbcAPI.aiLoad(m_Context,Application.streamingAssetsPath + m_StreamDesc.pathToAbc);
 
             if (m_Loaded)
             {
@@ -182,7 +182,7 @@ namespace UTJ.Alembic
             }
             else
             {
-                Debug.LogError("failed to load alembic at " + m_StreamDesc.pathToAbc);
+                Debug.LogError("failed to load alembic at " + Application.streamingAssetsPath + m_StreamDesc.pathToAbc);
             }
         }
 

--- a/AlembicImporter/Assets/UTJ/Alembic/Scripts/Importer/AlembicStream.cs
+++ b/AlembicImporter/Assets/UTJ/Alembic/Scripts/Importer/AlembicStream.cs
@@ -24,8 +24,6 @@ namespace UTJ.Alembic
 
         public static void RemapStreamsWithPath(string oldPath , string newPath)
         {
-            var fullOldPath = Application.streamingAssetsPath + oldPath;
-            var fullNewPath = Application.streamingAssetsPath + newPath;
             s_Streams.ForEach(s =>
             {
                 if (s.m_StreamDesc.pathToAbc == oldPath)
@@ -38,7 +36,6 @@ namespace UTJ.Alembic
 
         public static void ReconnectStreamsWithPath(string path)
         {
-            var fullPath = Application.streamingAssetsPath + path;
             s_Streams.ForEach(s =>
             {
                 if (s.m_StreamDesc.pathToAbc == path)


### PR DESCRIPTION
The field "pathToAbc" in AlembicStreamingDescriptor was filled with absolute paths. 
When making a build and deploying it to another PC, there was always an error: "failed to load alembic at...." because the absolute paths of the alembic streaming assets were different.
With these changes we save the relative paths in the field "pathToAbc", and we compute the absolute paths at runtime. 